### PR TITLE
CLI is able to disconnect clients at the server now

### DIFF
--- a/cli/src/CLI.cpp
+++ b/cli/src/CLI.cpp
@@ -72,8 +72,10 @@ void CLI::handleCommand(const std::string& command) {
   } else if (cmd == "close") {
     int id;
     iss >> id;
-    if (iss) {
-      // todo request to close client
+    if (iss and id >= 0) {
+      messages::ConnectionDisconnection message;
+      message.uuid = id;
+      sender->send(socket->getFD(), message);
     } else {
       std::cerr << "Invalid input" << std::endl;
     }

--- a/client/src/ClientApp.cpp
+++ b/client/src/ClientApp.cpp
@@ -43,27 +43,30 @@ void Client::receiveLoop() {
     messages::Message message = receiver->receive(socket->getFD());
 
     // TODO not all messages belong to client app
-    std::visit(
-        utils::overload{[](messages::Data& msg) {
-                          spdlog::info("Data received");
-                          std::cout << msg.data << std::endl;
-                        },
-                        [](messages::ConnectionRequest& msg) {
-                          spdlog::info("ConnectionRequest received");
-                        },
-                        [](messages::ConnectionRequestAccept& msg) {
-                          spdlog::info("ConnectionRequestAccept received");
-                        },
-                        [](messages::ConnectionRequestAcceptAck& msg) {
-                          spdlog::info("ConnectionRequestAcceptAck received");
-                        },
-                        [](messages::ConnectionRequestRefuse& msg) {
-                          spdlog::info("ConnectionRequestRefuse received");
-                        },
-                        [](messages::ConnectionDisconnection& msg) {
-                          spdlog::info("ConnectionDisconnection received");
-                        }},
-        message);
+    std::visit(utils::overload{
+                   [](messages::Data& msg) {
+                     spdlog::info("Data received");
+                     std::cout << msg.data << std::endl;
+                   },
+                   [](messages::ConnectionRequestAccept& msg) {
+                     spdlog::info("ConnectionRequestAccept received");
+                   },
+                   [](messages::ConnectionRequestRefuse& msg) {
+                     spdlog::info("ConnectionRequestRefuse received");
+                   },
+                   [](messages::ConnectionDisconnection& msg) {
+                     spdlog::info("ConnectionDisconnection received");
+                   },
+                   [](messages::ConnectionRequest& msg) {  // Discard
+                     return;
+                   },
+                   [](messages::ConnectionRequestAcceptAck& msg) {  // Discard
+                     return;
+                   },
+                   [](messages::Null) {  // Discard
+                     return;
+                   }},
+               message);
   }
 }
 

--- a/libs/core/src/core/Sender.cpp
+++ b/libs/core/src/core/Sender.cpp
@@ -136,6 +136,10 @@ void Sender::send(const types::FD socket, messages::Message message) {
                  },
                  [&](messages::ConnectionDisconnection& msg) {
                    send_internal(socket, serializeConnectionDisconnection(msg));
+                 },
+                 [](messages::Null) {
+                   // Discard
+                   return;
                  }},
              message);
 }

--- a/libs/messages/CMakeLists.txt
+++ b/libs/messages/CMakeLists.txt
@@ -7,7 +7,8 @@ set(HEADERS
     include/messages/ConnectionRequestAcceptAck.hpp
     include/messages/ConnectionRequestRefuse.hpp
     include/messages/Data.hpp
-    include/messages/Message.hpp)
+    include/messages/Message.hpp
+    include/messages/Null.hpp)
 set(SOURCES)
 
 add_library(${MODULE_LIB} ${HEADERS} ${SOURCES})

--- a/libs/messages/include/messages/Message.hpp
+++ b/libs/messages/include/messages/Message.hpp
@@ -8,11 +8,13 @@
 #include "messages/ConnectionRequestAcceptAck.hpp"
 #include "messages/ConnectionRequestRefuse.hpp"
 #include "messages/Data.hpp"
+#include "messages/Null.hpp"
 
 // clang-format off
 namespace messages {
 using Message =
     std::variant<
+        messages::Null,
         messages::ConnectionDisconnection,
         messages::ConnectionRequest,
         messages::ConnectionRequestAccept,

--- a/libs/messages/include/messages/Null.hpp
+++ b/libs/messages/include/messages/Null.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+/*
+Purpose of this message is to discard unnecessary data on the socket.
+During closing connections wiht cli or client it send tcp fin,ack etc., which
+cause problem during deserialization
+*/
+
+namespace messages {
+struct Null {};
+}  // namespace messages

--- a/server/src/ServerApp.cpp
+++ b/server/src/ServerApp.cpp
@@ -86,17 +86,20 @@ void Server::handleClient(types::FD socket) {
                       [](messages::ConnectionRequest& msg) {
                         spdlog::info("ConnectionRequest received");
                       },
-                      [](messages::ConnectionRequestAccept& msg) {
-                        spdlog::info("ConnectionRequestAccept received");
-                      },
                       [](messages::ConnectionRequestAcceptAck& msg) {
                         spdlog::info("ConnectionRequestAcceptAck received");
                       },
-                      [](messages::ConnectionRequestRefuse& msg) {
-                        spdlog::info("ConnectionRequestRefuse received");
-                      },
                       [](messages::ConnectionDisconnection& msg) {
                         spdlog::info("ConnectionDisconnection received");
+                      },
+                      [](messages::ConnectionRequestAccept&) {  // Discard
+                        return;
+                      },
+                      [](messages::ConnectionRequestRefuse&) {  // Discard`
+                        return;
+                      },
+                      [](messages::Null) {  // Discard
+                        return;
                       }},
       message);
 }


### PR DESCRIPTION
CLI sends ConnectionDisconnection mesage now
There were problem during exit with CLI. Socket had to close connection with tcp fin, ack, what caused receiver to not properly deserialize data:
1)empty buffer caused wrong deserialize
2)there was need somehow to catch such cases-added Null message similar to /dev/null at Linux